### PR TITLE
chore: gitignore support CLion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Clangd
 .cache/
+
+# Build output
 build*
+
+# CLion
+.idea/
+cmake-build-debug/
+cmake-build-release/


### PR DESCRIPTION
Hi, MegPeak authors
This PR update .gitignore file, support CLion users, and also add some comments for each entry.