### PR TITLE
feat(cpu): add bfmmla and change sdot to .inst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 
 if(MEGPEAK_ENABLE_DOT)
     message(STATUS "Enable dotprod feature in armv8.2-a")
-    set(CMAKE_CXX_FLAGS " -D__ARM_FEATURE_DOTPROD=1 -march=armv8.2-a+dotprod ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS " -D__ARM_FEATURE_DOTPROD=1 ${CMAKE_CXX_FLAGS}")
 endif()
 if(MEGPEAK_ENABLE_MMA)
     message(STATUS "Enable smmla feature in armv8.6-a")

--- a/src/cpu/aarch64.cpp
+++ b/src/cpu/aarch64.cpp
@@ -239,7 +239,7 @@ void megpeak::aarch64() {
     benchmark(mul_throughput, mul_latency, "mul");
 #if defined(__ARM_FEATURE_MATMUL_INT8)
     benchmark(smmla_throughput, smmla_latency, "smmla", 64);
-    benchmark(bfmmla_throughput, bfmmla_latency, "bfmmla", 64);
+    benchmark(bfmmla_throughput, bfmmla_latency, "bfmmla", 32);
 #endif
     benchmark(addp_throughput, addp_latency, "addp");
 #if __ARM_FEATURE_DOTPROD

--- a/src/cpu/aarch64.cpp
+++ b/src/cpu/aarch64.cpp
@@ -203,10 +203,10 @@ LATENCY(cb, mla)
 
 #if __ARM_FEATURE_DOTPROD
 
-#define cb(i) "sdot v" #i ".4s, v" #i ".16b, v" #i ".16b\n"
+#define cb(i) SDOT(i, i, i)
 THROUGHPUT(cb, sdot)
 #undef cb
-#define cb(i) "sdot v0.4s, v0.16b, v0.16b\n"
+#define cb(i) SDOT(0, 0, 0)
 LATENCY(cb, sdot)
 #undef cb
 
@@ -218,6 +218,13 @@ THROUGHPUT(cb, smmla)
 #undef cb
 #define cb(i) SMMLA(0, 0, 0)
 LATENCY(cb, smmla)
+#undef cb
+
+#define cb(i) BFMMLA(i, i, i)
+THROUGHPUT(cb, bfmmla)
+#undef cb
+#define cb(i) BFMMLA(0, 0, 0)
+LATENCY(cb, bfmmla)
 #undef cb
 #endif
 
@@ -232,6 +239,7 @@ void megpeak::aarch64() {
     benchmark(mul_throughput, mul_latency, "mul");
 #if defined(__ARM_FEATURE_MATMUL_INT8)
     benchmark(smmla_throughput, smmla_latency, "smmla", 64);
+    benchmark(bfmmla_throughput, bfmmla_latency, "bfmmla", 64);
 #endif
     benchmark(addp_throughput, addp_latency, "addp");
 #if __ARM_FEATURE_DOTPROD

--- a/src/cpu/common.h
+++ b/src/cpu/common.h
@@ -165,12 +165,18 @@ inline static void benchmark(std::function<int()> throughtput_func,
 #define DEC_TO_BIN(val) _DEC_BIN_##val
 
 // new instruction op code & flag
+#define sdot_code "01001111100" // code[1] = 0 if compute 2s/8b; code[-1] = 1 if offset = 1/3
+#define sdot_flag "111000"  // flag[4] = 1 if offset = 2/3
 #define smmla_code "01001110100"
 #define smmla_flag "101001"
+#define bfmmla_code "01101110010"
+#define bfmmla_flag "111011"
 
 #define AARCH64_BINARY_INST(op, dst, src1, src2) ".inst 0b" op##_code DEC_TO_BIN(dst) op##_flag DEC_TO_BIN(src1) DEC_TO_BIN(src2) "\n"
 // new instruction define
+#define SDOT(vd, vn, vm) AARCH64_BINARY_INST(sdot, vm, vn, vd)
 #define SMMLA(vd, vn, vm) AARCH64_BINARY_INST(smmla, vm, vn, vd)
+#define BFMMLA(vd, vn, vm) AARCH64_BINARY_INST(bfmmla, vm, vn, vd)
 
 void aarch64();
 void armv7();


### PR DESCRIPTION
- Add `bfmmla` instruction.
- Change `sdot` to `.inst` to reduce compile dependencies.
