### PR TITLE
fix(cpu): fix three tiny bugs

### DIFF
--- a/android_build.sh
+++ b/android_build.sh
@@ -21,14 +21,14 @@ function usage() {
     echo "-d : enable build with dotprod"
     echo "-a : enable build with mma"
     echo "-l : enable build with opencl"
-    echo "-a : enable all benchmark"
+    echo "-t : enable total benchmark"
     echo "-c : enable build with cpuinfo"
     echo "-h : show usage"
     echo "example: $0 -m armeabi-v7a"
     exit -1
 }
 
-while getopts "adlchm:a" arg
+while getopts "adlchm:t" arg
 do
     case $arg in
         m)
@@ -56,8 +56,8 @@ do
             usage
             exit 0
             ;;
-        a)
-            echo "build with all benchmark"
+        t)
+            echo "build with total benchmark"
             ALL_BENCHMARK=ON
             ;;
     esac


### PR DESCRIPTION
	1. If set CPU affinity failed, exit rather than continue.
	2. In function src/cpu/backend.cpp:bandwidth, initial 'src' and 'dst' to make sure 'memcpy' actually copies the data.
	3. Fix command line option of 'android_build.sh'.

@chenqy4933 帮忙review一下吧。前两个bug是同事提的；第三个是因为我之前没有更新我fork的仓库，最新的代码'-a'选项已经被使用了，改成了'-t'。